### PR TITLE
Bump python version to 3.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=parse_requirements_file("requirements.txt"),
-    python_requires=">=3.8.0,<3.11",
+    python_requires=">=3.8.0,<3.12",
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Framework :: AsyncIO",


### PR DESCRIPTION
WTF does not seem to have problems with python 3.11. This commit is to bump the python version up to it if you'd like @tandemdude 